### PR TITLE
fix paths with actix-web v4

### DIFF
--- a/actix-plus-static-files/src/impl.rs
+++ b/actix-plus-static-files/src/impl.rs
@@ -102,11 +102,7 @@ impl Deref for ResourceFiles {
 
 impl HttpServiceFactory for ResourceFiles {
     fn register(self, config: &mut AppService) {
-        let rdef = if config.is_root() {
-            ResourceDef::root_prefix(&self.path)
-        } else {
-            ResourceDef::prefix(&self.path)
-        };
+        let rdef = ResourceDef::root_prefix(self.path.trim_end_matches('/'));
         config.register_service(rdef, None, self, None)
     }
 }


### PR DESCRIPTION
This should keep the original behavior with v4. `ResourceFiles::new("/", _)` should now work as expected. This will internally convert `"/" -> ""`

I'm unsure what advatages this crate have over `actix-files`?